### PR TITLE
update @polkadot/api version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "sa",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@polkadot/api": "^5.7.1",
+    "@polkadot/api": "^6",
     "@subql/types": "latest",
     "typescript": "^4.1.3",
     "@subql/cli": "latest"


### PR DESCRIPTION
I have an error with npm install locally, this fix resolves it.
An error:


>  npm i                                                                                                                                                                             Mon 20 Dec 16:48:01 2021
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: account-transfers@1.0.0
npm ERR! Found: @polkadot/api@5.9.1
npm ERR! node_modules/@polkadot/api
npm ERR!   dev @polkadot/api@"^5.7.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @polkadot/api@"^6" from @subql/types@0.11.0
npm ERR! node_modules/@subql/types
npm ERR!   dev @subql/types@"latest" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.